### PR TITLE
Idea 15 and 14 support

### DIFF
--- a/src/main/java/org/codinjutsu/tools/jenkins/view/JenkinsWidget.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/JenkinsWidget.java
@@ -19,12 +19,15 @@ package org.codinjutsu.tools.jenkins.view;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Disposer;
-import com.intellij.openapi.wm.*;
+import com.intellij.openapi.wm.CustomStatusBarWidget;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.components.panels.NonOpaquePanel;
 import org.codinjutsu.tools.jenkins.JenkinsWindowManager;
 import org.codinjutsu.tools.jenkins.logic.BuildStatusAggregator;
 import org.codinjutsu.tools.jenkins.view.util.BuildStatusIcon;
+import org.codinjutsu.tools.jenkins.view.util.WidgetBorderUtil;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -80,7 +83,7 @@ public class JenkinsWidget extends NonOpaquePanel implements CustomStatusBarWidg
             }
         });
 
-        setBorder(WidgetBorder.INSTANCE);
+        setBorder(WidgetBorderUtil.getBorderInstance());
 
         return statusIcon;
     }

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/util/WidgetBorderUtil.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/util/WidgetBorderUtil.java
@@ -1,0 +1,55 @@
+package org.codinjutsu.tools.jenkins.view.util;
+
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.util.ui.JBEmptyBorder;
+import com.intellij.util.ui.JBUI;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.border.Border;
+import java.lang.reflect.Field;
+
+/**
+ * Created by Cezary Butler on 2015-11-13.
+ */
+public class WidgetBorderUtil {
+    private static final Logger logger = Logger.getLogger(WidgetBorderUtil.class);
+
+    private static Border INSTANCE;
+
+    public static Border getBorderInstance(){
+        if (INSTANCE == null) {
+            INSTANCE = locateBorderInstance();
+        }
+        return INSTANCE;
+    }
+
+    public static Border locateBorderInstance() {
+        try {
+            return StatusBarWidget.WidgetBorder.INSTANCE;
+        }catch(NoSuchFieldError nsf){
+            final Border borderInstance = getUsingReflection();
+            if (borderInstance != null) return borderInstance;
+        }
+        return fallbackMethod();
+    }
+
+    @NotNull
+    private static JBEmptyBorder fallbackMethod() {
+        return JBUI.Borders.empty(0, 2);
+    }
+
+    @Nullable
+    private static Border getUsingReflection() {
+        logger.info("Instance field not found, trying to locate one using reflection");
+        try {
+            final Field borderInstance = StatusBarWidget.WidgetBorder.class.getField("INSTANCE");
+            return (Border) borderInstance.get(null);
+        } catch (NoSuchFieldException | IllegalAccessException e ) {
+            logger.log(Level.WARN, "Exception occurred while trying to fetch border", e);
+        }
+        return null;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,13 +1,13 @@
 <idea-plugin>
     <name>Jenkins Control Plugin</name>
     <description>A Jenkins Plugin for Intellij</description>
-    <version>0.9.3-Programisci-2</version>
+    <version>0.9.3-Programisci-3</version>
     <vendor email="david.boissier [at] gmail [dot] com" url="http://codinjutsu.blogspot.com">
         David Boissier,
         Yuri Novitsky (support of PPP),
         Programisci.eu (bugfix)
     </vendor>
-    <idea-version since-build="131.00000"/>
+    <idea-version since-build="141.00000" />
 
     <depends>com.intellij.modules.lang</depends>
 


### PR DESCRIPTION
I've compared our builds and it turned out there's no meaningfull difference between them. It's just i've used _Idea 15_ to make this build (even tough I had set Idea 14 SDK). My build turns out to be _Idea 15_ compatible and yours _Idea 14_ compatibile. 
Then I went to Idea platform source, and there I found something interesting. Field that is reported missing, changed type from _WidgetBorder_ to _Border_. I suspect that there is compiled in type information that prevents jre from finding right field in runtime when running with different jar than compiled with.
I made solution that works for me on both _Idea 14_ and _Idea 15_.
Because of fallback method used in util plugin will no longer work with _Idea 13_, this can be changed by removing fallback (_JBUI.Borders.empty(0, 2);_)